### PR TITLE
Fix removing of previous events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ export default class Idle extends Component {
 
   componentDidUpdate(prevProps) {
     if (eventsChanged(prevProps.events, this.props.events)) {
-      this.removeEvents()
+      this.removeEvents(prevProps.events)
       this.attachEvents()
     }
   }
@@ -40,8 +40,8 @@ export default class Idle extends Component {
     })
   }
 
-  removeEvents() {
-    this.props.events.forEach(event => {
+  removeEvents(events = this.props.events) {
+    events.forEach(event => {
       window.removeEventListener(event, this.handleEvent)
     })
   }


### PR DESCRIPTION
If I'm not mistaken, only the new events were removed and then registered again after an update of the events prop which means that events which are not in the list anymore will remain registered.