### PR TITLE
Prevent setState being called on unmounted component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ export default class Idle extends Component {
 
   componentWillUnmount() {
     this.removeEvents()
+    clearTimeout(this.timeout);
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
If an instance of `React Idle` was unmounted and there was a timeout still occurring, then `setState` was being called on the unmounted instance of `React Idle`.