### PR TITLE
removeEventListener  options as addEventListener

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ export default class Idle extends Component {
 
   removeEvents() {
     this.props.events.forEach(event => {
-      window.removeEventListener(event, this.handleEvent)
+      window.removeEventListener(event, this.handleEvent, true)
     })
   }
 


### PR DESCRIPTION
You add the listener:
```js
window.removeEventListener(event, this.handleEvent)
```

but you remove it with a diff options:
```js
window.removeEventListener(event, this.handleEvent, true)
```

By the docs, you have to remove and add the listener with the same options
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener#Matching_event_listeners_for_removal

> Matching event listeners for removal
> 
> Given an event listener previously added by calling addEventListener(), you may eventually come to a point at which you need to remove it. Obviously, you need to specify the same type and listener parameters to removeEventListener(), but what about the options or useCapture parameters?
> 
> While addEventListener() will let you add the same listener more than once for the same type if the options are different, the only option removeEventListener() checks is the capture/useCapture flag. Its value must match for removeEventListener() to match, but the other values don't.
  